### PR TITLE
Fix request building for basic auth

### DIFF
--- a/src/main/groovy/com/redpillanalytics/KsqlRest.groovy
+++ b/src/main/groovy/com/redpillanalytics/KsqlRest.groovy
@@ -44,16 +44,17 @@ class KsqlRest {
       def prepared = (ksql + ';').replace('\n', '').replace(';;', ';')
 
       if (['create', 'drop'].contains(getStatementType(ksql))) log.info prepared
-      HttpResponse<String> response = Unirest.post("${restUrl}/ksql")
+      RequestBodyEntity request = Unirest.post("${restUrl}/ksql")
               .header("Content-Type", "application/vnd.ksql.v1+json")
               .header("Cache-Control", "no-cache")
               .header("Postman-Token", "473fbb05-9da1-4020-95c0-f2c60fed8289")
               .body(JsonOutput.toJson([ksql: prepared, streamsProperties: properties]))
-              .asString()
 
       // streamline the addition of basic credentials slightly
       if (username && password)
-         response.header("Authorization", "Basic " + "${username}:${password}".bytes.encodeBase64().toString())
+         request.basicAuth(username, password)
+
+      HttpResponse<String> response = request.asString()
 
       log.debug "unirest response: ${response.dump()}"
       def body = new JsonSlurper().parseText(response.body)


### PR DESCRIPTION
I'm not sure if `RequestBodyEntity` is the best type to declare the request as. I tried to find a base entity type I could use instead but I'm not sure what would be valid to put as the `R` in `HttpRequest<R>`.