### PR TITLE
Add retry behavior for dropping a query

### DIFF
--- a/src/main/groovy/com/redpillanalytics/gradle/ConfluentExtension.groovy
+++ b/src/main/groovy/com/redpillanalytics/gradle/ConfluentExtension.groovy
@@ -106,6 +106,16 @@ class ConfluentExtension {
    Integer statementPause = 0
 
    /**
+    * The number of seconds to pause execution before retrying a drop statement. Default: 10
+    */
+   Integer dropRetryPause = 10
+
+   /**
+    * The maximum number of times drop statements are to be retried. Default: 10
+    */
+   Integer dropMaxRetries = 10
+
+   /**
     * Provides the path for Pipeline source files.
     *
     * @return The full path of the Pipeline source files. Uses {@link #pipelineSourcePath} first if it exists, and if it doesn't (the default), then it uses {@link #sourceBase} and {@link #pipelineSourceName}.

--- a/src/main/groovy/com/redpillanalytics/gradle/tasks/PipelineExecuteTask.groovy
+++ b/src/main/groovy/com/redpillanalytics/gradle/tasks/PipelineExecuteTask.groovy
@@ -67,6 +67,26 @@ class PipelineExecuteTask extends PipelineEndpointTask {
    )
    String statementPause = project.extensions.confluent.statementPause.toString()
 
+   /**
+    * The number of seconds to pause execution before retrying a drop statement. Default: value of 'confluent.dropRetryPause'.
+    */
+   @Input
+   @Optional
+   @Option(option = "drop-retry-pause",
+           description = "The number of seconds to pause execution before retrying a drop statement. Default: value of 'confluent.dropRetryPause'."
+   )
+   String dropRetryPause = project.extensions.confluent.dropRetryPause.toString()
+
+   /**
+    * The maximum number of times drop statements are to be retried. Default: value of 'confluent.dropMaxRetries'.
+    */
+   @Input
+   @Optional
+   @Option(option = "drop-max-retries",
+           description = "The maximum number of times drop statements are to be retried. Default: value of 'confluent.dropMaxRetries'."
+   )
+   String dropMaxRetries = project.extensions.confluent.dropMaxRetries.toString()
+
    def doSkip(it) {
       boolean setCmd = it.toString().toLowerCase().startsWith("set ")
       boolean unsetCmd = it.toString().toLowerCase().startsWith("unset ")
@@ -88,6 +108,8 @@ class PipelineExecuteTask extends PipelineEndpointTask {
       Integer numCreated = 0
       Integer numDropped = 0
 
+      Integer dropRetryPause = dropRetryPause.toInteger()
+      Integer dropMaxRetries = dropMaxRetries.toInteger()
 
       // first execute the DROP KSQL statements
       // this also catches running statements and terminates them
@@ -143,7 +165,7 @@ class PipelineExecuteTask extends PipelineEndpointTask {
                }
 
                // execute the statement
-               def result = ksqlRest.dropKsql(sql, [:])
+               def result = ksqlRest.dropKsql(sql, [:], dropRetryPause, dropMaxRetries)
 
                // write the analytics record if the analytics plugin is there
                if (project.rootProject.plugins.findPlugin('com.redpillanalytics.gradle-analytics')) {


### PR DESCRIPTION
Issue: when drop query is submitted, in some cases command id is null. This can happen when ksql is busy processsing other commands.
Fix: Retry a drop query until a command id is received